### PR TITLE
Redirect old 2023 festival URL to new one

### DIFF
--- a/_layouts/redirected.html
+++ b/_layouts/redirected.html
@@ -1,0 +1,15 @@
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="canonical" href="{{ page.redirect_to }}"/>
+<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<meta http-equiv="refresh" content="0;url={{ page.redirect_to }}" />
+</head>
+<body>
+    <h1>Redirecting...</h1>
+      <a href="{{ page.redirect_to }}">Click here if you are not redirected.<a>
+      <script>location='{{ page.redirect_to }}'</script>
+</body>
+</html>

--- a/resbaz/resbazTucson2023.md
+++ b/resbaz/resbazTucson2023.md
@@ -1,0 +1,8 @@
+---
+layout: redirected
+sitemap: false
+permalink: /resbaz/resbazTucson2023/
+redirect_to: /resbaz/Arizona2023/
+---
+
+


### PR DESCRIPTION
Followed these instructions: https://superdevresources.com/redirects-jekyll-github-pages/#utilizing-a-redirected-layout