### PR TITLE
Fix: update communications channels

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -32,9 +32,11 @@ Meet new people in and outside of your field. Join our supportive network of dat
 
 ## Events
 
+::: {.content-hidden}
 _Stay up to date on announcements at our Twitter: [@ResBazAZ](https://twitter.com/ResBazAZ)_
 
 _(Optionally) RSVP for our events at Meetup: [Our MeetUp](https://www.meetup.com/ResBazAZ/)_
+:::
 
 ### Coffee and Code
 

--- a/index.qmd
+++ b/index.qmd
@@ -16,7 +16,7 @@ import { randomAvatars } from './components/randomAvatars.ojs';
 
 ## What we do
 
-_Need help now? Want to talk? Go post in our Gitter: [resbaz/Arizona](https://gitter.im/resbaz/Arizona)_
+_The ResBaz Arizona community is most active on Slack. [Join us!](https://resbazaz.slack.com/signup)_
 
 ### Everyone is welcome
 


### PR DESCRIPTION
Fixes #105.  No need to generate special invite links that expire. Point people directly to the self-signup page.

Also hid some links to dormant outreach channels such as twitter and Meetup.